### PR TITLE
Add weights to TS definition

### DIFF
--- a/regression-multivariate-linear.d.ts
+++ b/regression-multivariate-linear.d.ts
@@ -15,6 +15,7 @@ declare module 'ml-regression-multivariate-linear' {
     stdErrorMatrix: Matrix;
     stdErrors: number[];
     tStats: number[];
+    weights: number[][];
 
     constructor(
       x: number[][] | AbstractMatrix,


### PR DESCRIPTION
I'm using the `weights` property after getting a MLR; and my linter is complaining that it doesn't exist.  Adding this to the definition fixes it.